### PR TITLE
Fix rounding error for grass tips

### DIFF
--- a/assets/shaders/grass.shader
+++ b/assets/shaders/grass.shader
@@ -66,7 +66,7 @@ void fragment() {
 			}
 			
 			// Color basec on distance from root
-			if (dist == blade_length) {
+			if (abs(dist - blade_length) < 0.0000001) {
 				// Color grass tips
 				if (wind <= 0.5f) {
 					COLOR = tip_color;


### PR DESCRIPTION
Fixes #1, where a rounding error could lead to the grass tips not being colored correctly. Distance to root and bale length are now compared with an epsilon value, as they should be.

Thanks @zhaishengfu!